### PR TITLE
Add "Verify is closed" banner to prep repo for archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Dropwizard JUnit Runner
+
+>**GOV.UK Verify has closed**
+>
+>This repository is out of date and has been archived
+
 > JUnit Runner implementation that starts up [DropwizardTestSupport](http://www.dropwizard.io/1.2.0/docs/manual/testing.html) 
 > applications globally based on the provided configuration
 
@@ -33,7 +38,7 @@ public class MyClassTest {
     
 Distributed under the MIT license. See ``LICENSE`` for more information.
 
-[Goverment Digital Service](https://github.com/alphagov)
+[Government Digital Service](https://github.com/alphagov)
 
 ## Contributing
 


### PR DESCRIPTION
As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.